### PR TITLE
feat: Add stub TpStreamsPlayerView component

### DIFF
--- a/android/src/main/java/com/tpstreams/TpStreamsPlayerView.kt
+++ b/android/src/main/java/com/tpstreams/TpStreamsPlayerView.kt
@@ -1,0 +1,11 @@
+package com.tpstreams
+
+import android.content.Context
+import android.graphics.Color
+import android.view.View
+
+class TpStreamsPlayerView(context: Context) : View(context) {
+    init{
+        setBackgroundColor(Color.DKGRAY)
+    }
+}

--- a/android/src/main/java/com/tpstreams/TpStreamsPlayerViewManager.kt
+++ b/android/src/main/java/com/tpstreams/TpStreamsPlayerViewManager.kt
@@ -1,0 +1,13 @@
+package com.tpstreams
+
+import com.facebook.react.uimanager.SimpleViewManager
+import com.facebook.react.uimanager.ThemedReactContext
+
+class TpStreamsPlayerViewManager : SimpleViewManager<TpStreamsPlayerView>() {
+
+    override fun getName() = "TpStreamsPlayerView"
+
+    override fun createViewInstance(reactContext : ThemedReactContext) :TpStreamsPlayerView {
+        return TpStreamsPlayerView(reactContext)
+    }
+}

--- a/android/src/main/java/com/tpstreams/TpstreamsPackage.kt
+++ b/android/src/main/java/com/tpstreams/TpstreamsPackage.kt
@@ -5,6 +5,7 @@ import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
+import com.facebook.react.uimanager.ViewManager
 import java.util.HashMap
 
 class TpstreamsPackage : BaseReactPackage() {
@@ -29,5 +30,9 @@ class TpstreamsPackage : BaseReactPackage() {
       )
       moduleInfos
     }
+  }
+
+  override fun createViewManagers(reactContext: ReactApplicationContext) : List<ViewManager<*, *>> {
+    return listOf(TpStreamsPlayerViewManager())
   }
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,20 +1,42 @@
-import { Text, View, StyleSheet } from 'react-native';
-import { multiply } from 'react-native-tpstreams';
+import { View, Text } from 'react-native';
+import TpStreamsPlayerView from 'react-native-tpstreams';
+import type { PlayerProps } from 'react-native-tpstreams';
 
-const result = multiply(3, 7);
+const App = () => {
+  const playerProps: PlayerProps = {
+    source: {
+      uri: 'https://example.com/video.mp4',
+      drm: {
+        type: 'widevine',
+        licenseServer: 'https://example.com/license',
+        headers: {
+          Authorization: 'Bearer your_token',
+        },
+      },
+    },
+    style: { width: '100%', height: 200 },
+  };
 
-export default function App() {
   return (
-    <View style={styles.container}>
-      <Text>Result: {result}</Text>
+    <View
+      style={{
+        flex: 1,
+        justifyContent: 'flex-start',
+        alignItems: 'center',
+        paddingTop: 20,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 18,
+          fontWeight: 'bold',
+        }}
+      >
+        Example Player
+      </Text>
+      <TpStreamsPlayerView {...playerProps} />
     </View>
   );
-}
+};
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,15 @@
 import Tpstreams from './NativeTpstreams';
+import { requireNativeComponent } from 'react-native';
 import type { PlayerProps, DRM, Source } from './types';
 
 export function multiply(a: number, b: number): number {
   return Tpstreams.multiply(a, b);
 }
 
+const TpStreamsPlayerView = requireNativeComponent<PlayerProps>(
+  'TpStreamsPlayerView'
+);
+
+export default TpStreamsPlayerView;
 // Re-export types for external usage
 export type { DRM, Source, PlayerProps };


### PR DESCRIPTION
- Implement a stub `TpStreamsPlayerView` as a native Android view.
- Add a view manager to bridge it with React Native.
- Register the view manager in `TpstreamsPackage.kt`.
- Add a gray box to mimic the player in the stub.